### PR TITLE
Split status code from store so we can require just these

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,5 @@
 var objectAssign = require('object-assign');
-
-var statusCodes = {
-    INITIAL: "INITIAL",
-    READY: "READY",
-    PENDING: "PENDING",
-    FAILED: "FAILED"
-};
+var statusCodes = require('./statusCodes');
 
 module.exports = {
     init: function() {

--- a/statusCodes.js
+++ b/statusCodes.js
@@ -1,0 +1,6 @@
+module.exports = {
+    INITIAL: "INITIAL",
+    READY: "READY",
+    PENDING: "PENDING",
+    FAILED: "FAILED"
+};


### PR DESCRIPTION
Enables `var statusCodes = require('reflux-store-status/statusCodes');`
