### PR TITLE
Update for reflux 0.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/rvdkooy/reflux-store-status"
   },
   "devDependencies": {
-    "reflux": "^0.2.12",
     "browserify": "^10.2.3",
     "es5-shim": "^4.1.0",
     "gulp": "^3.8.11",
@@ -24,13 +23,15 @@
     "karma-browserify": "^4.2.1",
     "karma-chrome-launcher": "~0.1.2",
     "karma-jasmine": "^0.2.2",
-    "karma-phantomjs-launcher": "~0.1.2"
+    "karma-phantomjs-launcher": "~0.1.2",
+    "react": "^15.1.0",
+    "reflux": "^0.4.1"
   },
   "peerDependencies": {
-    "reflux": ">=0.2.x"
+    "reflux": ">=0.4.x"
   },
   "dependencies": {
     "object-assign": "^3.0.0",
-    "reflux": "^0.3.0"
+    "reflux": "^0.4.1"
   }
 }


### PR DESCRIPTION
Because we want to use this with react 15.x we need to update reflux also
Reflux 0.2.x has peer dependency to react <0.14.x
